### PR TITLE
fixed -Werror and std::string error for OSX

### DIFF
--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -116,9 +116,12 @@ void Gui::_updateControls() {
   ImGui::End();
 
   ImGui::Begin("Commands");
+  ImGui::Text("Count: %zu", this->pushswap.commands.size());
+  ImGui::BeginChild("Scrolling");
   for (const auto &cmd : this->queues.commands) {
     ImGui::Text("%s", cmd.c_str());
   }
+  ImGui::EndChild();
   ImGui::End();
 }
 

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -111,13 +111,13 @@ void Gui::_updateControls() {
     status = "OK";
   }
   ImGui::SameLine();
-  ImGui::Text(status.c_str());
+  ImGui::Text("%s", status.c_str());
 
   ImGui::End();
 
   ImGui::Begin("Commands");
   for (const auto &cmd : this->queues.commands) {
-    ImGui::Text(cmd.c_str());
+    ImGui::Text("%s", cmd.c_str());
   }
   ImGui::End();
 }

--- a/src/queues.cpp
+++ b/src/queues.cpp
@@ -1,6 +1,7 @@
 #include "queues.h"
 #include <algorithm>
 #include <vector>
+#include <string>
 
 Queues::Queues()
     : commandMap{


### PR DESCRIPTION
Fixed 2 issues for OSX:
- ImGui::Text() formatting
- Missing <string> header in queues.cpp