### PR TITLE
Added precision in README, section Install and corrected 'make .' for 'make'

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,12 @@ You can read the subject [here](https://github.com/Binary-Hackers/42_Subjects/bl
 This project uses C++17, cmake, SFML and ImGui.
 - Install a C++ compiler (gcc, clang,...)
 - Install cmake
-- create a 'build' subfolder
+- Move push_swap_visualizer inside push_swap
+- Inside push_swap_visualizer, mkdir :
+    - 'build'
 - cd in the build folder and type :
     - 'cmake  ..'
-    - 'make .'
+    - 'make'
 - run the visualizer with ./bin/visualizer
 
 ![](https://i.imgur.com/zqcsZfY.png)

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -57,15 +57,8 @@ void Gui::_updateBars() {
 
 void Gui::_updateControls() {
   ImGui::Begin("Controls");
-  ImGui::SliderInt("Speed", &this->speed, 1, 240, "%i/s");
+  ImGui::SliderInt("Speed", &this->speed, 1, 500, "%i/s");
 
-  if (ImGui::Button("Load")) {
-    this->state = STATE::Stopped;
-    this->queues.start(Utils::SplitStringToInt(this->numbers, ' '));
-    this->queues.commands = this->pushswap.commands;
-  }
-
-  ImGui::SameLine();
   if (ImGui::Button("Start")) {
     this->state = STATE::Running;
   }
@@ -119,6 +112,10 @@ void Gui::_updateControls() {
   ImGui::InputText("", &this->pushswap.path);
   if (ImGui::Button("Compute")) {
     this->pushswap.run(this->numbers);
+    this->state = STATE::Stopped;
+    this->queues.start(Utils::SplitStringToInt(this->numbers, ' '));
+    this->queues.commands = this->pushswap.commands;
+    this->queues.executedCommands.clear();
   }
 
   std::string status{"..."};


### PR DESCRIPTION
I propose clearer instructions and removing the dot in the command :
' make .'

We don't need the '.'
Thanks for accepting those change, it will help many students !