### PR TITLE
feat: change standart directory, and make better look README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,71 @@
 # Push Swap Visualizer
+
 This project is a visualizer for the **"PUSH_SWAP"** 42 School Project.
 
 **Push Swap** is a program that takes as argument a space separated list of numbers and outputs a list of commands that can be used to sort them.
 
 You can read the subject [here](https://github.com/Binary-Hackers/42_Subjects/blob/master/00_Projects/02_Algorithmic/push_swap.pdf).
 
+## Install
+
+- Clone the `push_swap_visualizer` repository into the directory where your `push_swap` project is located:
+
+```bash
+git clone https://github.com/o-reo/push_swap_visualizer.git
+```
+
+This project uses C++17, cmake, SFML and ImGui.
+
+- Install required packages (if not already installed)
+  For Debian-based systems, you can install the necessary packages using the following commands:
+
+```bash
+sudo apt-get update
+sudo apt-get install cmake
+sudo apt-get install g++
+sudo apt-get install clang
+sudo apt-get install libgl1-mesa-dev libglu1-mesa-dev
+sudo apt-get install libx11-dev libxrandr-dev
+sudo apt-get install libudev-dev
+sudo apt-get install libfreetype-dev
+```
+
+- Navigate to the `push_swap_visualizer` directory, create `build` directory, and navigate into the build directory:
+
+```bash
+cd push_swap_visualizer
+mkdir build
+cd build
+```
+
+- Generate the build files using CMake and compile the visualizer:
+
+```bash
+cmake ..
+make
+```
+
+- Run the visualizer:
+
+```bash
+./bin/visualizer
+```
+
 ## Usage
 
-- If you add the program inside your project, you will need to add **../../** before the name of your program to make the visualizer work.
+- If you've relocated your push_swap program, simply update the visualizer's menu directory from "../../push_swap" to the new path of your push_swap program. For instance, "../../new_directory/push_swap".
 
 - In the **Values** window
-    - Choose the size of the push swap input with the slider [Optional]
-    - **Shuffle** the input [Optional]
-    - The space separated values should be filled automatically, you can also put your own values
-    - Set the Push Swap program path (Absolute or relative path).
-    - **Compute** the sort commands, it will display OK when done.
+  - Choose the size of the push swap input with the slider [Optional]
+  - **Shuffle** the input [Optional]
+  - The space separated values should be filled automatically, you can also put your own values
+  - Set the Push Swap program path (Absolute or relative path).
+  - **Compute** the sort commands, it will display OK when done.
 - In the **Controls** window
-    - **Load** the commands in the visualizer
-    - **Start** the animation
-    - Adjust the **Speed** as needed
-    - **Pause** and go **Step** by step to see the details of your algorithm.
-    - **Load** to restart the animation
-
-## Install
-This project uses C++17, cmake, SFML and ImGui.
-- Install a C++ compiler (gcc, clang,...)
-- Install cmake
-- Move push_swap_visualizer inside push_swap
-- Inside push_swap_visualizer, mkdir :
-    - 'build'
-- cd in the build folder and type :
-    - 'cmake  ..'
-    - 'make'
-- run the visualizer with ./bin/visualizer
+  - **Load** the commands in the visualizer
+  - **Start** the animation
+  - Adjust the **Speed** as needed
+  - **Pause** and go **Step** by step to see the details of your algorithm.
+  - **Load** to restart the animation
 
 ![](https://i.imgur.com/zqcsZfY.png)

--- a/src/pushswap.cpp
+++ b/src/pushswap.cpp
@@ -6,7 +6,7 @@
 #include <stdexcept>
 #include <string>
 
-PushSwap::PushSwap() : path{"./push_swap"} {}
+PushSwap::PushSwap() : path{"../../push_swap"} {}
 PushSwap::~PushSwap() {}
 
 void PushSwap::run(const std::string &numbers) {


### PR DESCRIPTION
In this Pull Request, I have proposed changes to improve the overall user experience and the convenience of setting up and running the visualizer. 

1. I have modified the default path to the `push_swap` file. Previously, the path was set to `./push_swap`, which required manual changes most of the time as the visualizer is generally cloned into the project folder. To eliminate this step for our users, I have changed the default path to `../../push_swap`. This should streamline the setup process and increase usability.

2. Updates have also been made to the `README.md` file for better comprehension and ease of installation. The 'Install' section is now at the top of the file, followed by the 'Usage' section. This change aligns with the natural flow of user interaction: users need to install the visualizer before learning about its interface and controls.

3. In addition, I have incorporated a comprehensive list of necessary libraries and packages in the README. This list will aid users in setting up and running the visualizer on a new machine. This change is in conjunction with the updated default path to `push_swap` in the program, reflected in the README file.

These changes are intended to enhance user convenience and facilitate a smoother setup and run process. I believe these modifications will prove beneficial to the user community. Your feedback and suggestions are most welcome.